### PR TITLE
Fix a terminal command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ git clone git@github.com:alephmelo/django-task-manager.git
 ```
 * Install packages with pip
 ```
-pip install requirements.txt
+pip install -r requirements.txt
 ```
 * Create database (Django default is sqlite3)
 ```


### PR DESCRIPTION
According to [documentation](http://pip.readthedocs.org/en/stable/user_guide/#installing-packages), we should pass a `-r` option when using a 'requirements.txt' in `pip install`.
